### PR TITLE
feat: add light/dark theme toggle and improve UI contrast

### DIFF
--- a/src/GLSLShaderLab.App.Wpf/App.xaml
+++ b/src/GLSLShaderLab.App.Wpf/App.xaml
@@ -4,6 +4,210 @@
              xmlns:local="clr-namespace:GLSLShaderLab.App.Wpf"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
-         
+        <!-- ===== DARK THEME (Default) ===== -->
+        <ResourceDictionary x:Key="DarkTheme">
+            <!-- Primary Colors -->
+            <Color x:Key="PrimaryBackground">#1E1E1E</Color>
+            <Color x:Key="SecondaryBackground">#252526</Color>
+            <Color x:Key="TertiaryBackground">#2D2D30</Color>
+            <Color x:Key="PrimaryForeground">#E0E0E0</Color>
+            <Color x:Key="SecondaryForeground">#A0A0A0</Color>
+            <Color x:Key="AccentColor">#007ACC</Color>
+            
+            <!-- Editor Colors -->
+            <Color x:Key="EditorBackground">#1E1E1E</Color>
+            <Color x:Key="EditorForeground">#D4D4D4</Color>
+            <Color x:Key="ScrollBarBackground">#252526</Color>
+            
+            <!-- Syntax Highlighting -->
+            <Color x:Key="CommentColor">#6A9955</Color>
+            <Color x:Key="KeywordColor">#569CD6</Color>
+            <Color x:Key="TypeColor">#4EC9B0</Color>
+            <Color x:Key="NumberColor">#B5CEA8</Color>
+            <Color x:Key="StringColor">#CE9178</Color>
+            <Color x:Key="PreprocessorColor">#C586C0</Color>
+            <Color x:Key="BuiltinColor">#DCDCAA</Color>
+            
+            <!-- UI Colors -->
+            <Color x:Key="ToolBarBackground">#2D2D30</Color>
+            <Color x:Key="StatusBarBackground">#2D2D30</Color>
+            <Color x:Key="TabBackground">#252526</Color>
+            <Color x:Key="TabForeground">#CCCCCC</Color>
+            <Color x:Key="TabSelectedBackground">#1E1E1E</Color>
+            <Color x:Key="BorderColor">#3E3E42</Color>
+            <Color x:Key="ButtonHoverBackground">#3E3E42</Color>
+            <Color x:Key="ButtonPressedBackground">#007ACC</Color>
+        </ResourceDictionary>
+
+        <!-- ===== LIGHT THEME ===== -->
+        <ResourceDictionary x:Key="LightTheme">
+            <!-- Primary Colors -->
+            <Color x:Key="PrimaryBackground">#FFFFFF</Color>
+            <Color x:Key="SecondaryBackground">#F5F5F5</Color>
+            <Color x:Key="TertiaryBackground">#EFEFEF</Color>
+            <Color x:Key="PrimaryForeground">#1E1E1E</Color>
+            <Color x:Key="SecondaryForeground">#5A5A5A</Color>
+            <Color x:Key="AccentColor">#0066CC</Color>
+            
+            <!-- Editor Colors -->
+            <Color x:Key="EditorBackground">#FFFFFF</Color>
+            <Color x:Key="EditorForeground">#000000</Color>
+            <Color x:Key="ScrollBarBackground">#F5F5F5</Color>
+            
+            <!-- Syntax Highlighting -->
+            <Color x:Key="CommentColor">#008000</Color>
+            <Color x:Key="KeywordColor">#0000FF</Color>
+            <Color x:Key="TypeColor">#2B91AF</Color>
+            <Color x:Key="NumberColor">#098658</Color>
+            <Color x:Key="StringColor">#A31515</Color>
+            <Color x:Key="PreprocessorColor">#0000FF</Color>
+            <Color x:Key="BuiltinColor">#795E26</Color>
+            
+            <!-- UI Colors -->
+            <Color x:Key="ToolBarBackground">#F5F5F5</Color>
+            <Color x:Key="StatusBarBackground">#F5F5F5</Color>
+            <Color x:Key="TabBackground">#EFEFEF</Color>
+            <Color x:Key="TabForeground">#333333</Color>
+            <Color x:Key="TabSelectedBackground">#FFFFFF</Color>
+            <Color x:Key="BorderColor">#CCCCCC</Color>
+            <Color x:Key="ButtonHoverBackground">#E0E0E0</Color>
+            <Color x:Key="ButtonPressedBackground">#0066CC</Color>
+        </ResourceDictionary>
+
+        <!-- ===== MERGED RESOURCES (Active Theme) ===== -->
+        <!-- Primary Colors -->
+        <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#1E1E1E"/>
+        <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#252526"/>
+        <SolidColorBrush x:Key="TertiaryBackgroundBrush" Color="#2D2D30"/>
+        <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#E0E0E0"/>
+        <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#A0A0A0"/>
+        <SolidColorBrush x:Key="AccentBrush" Color="#007ACC"/>
+        
+        <!-- Editor -->
+        <SolidColorBrush x:Key="EditorBackgroundBrush" Color="#1E1E1E"/>
+        <SolidColorBrush x:Key="EditorForegroundBrush" Color="#D4D4D4"/>
+        <SolidColorBrush x:Key="ScrollBarBackgroundBrush" Color="#252526"/>
+        
+        <!-- Syntax -->
+        <SolidColorBrush x:Key="CommentBrush" Color="#6A9955"/>
+        <SolidColorBrush x:Key="KeywordBrush" Color="#569CD6"/>
+        <SolidColorBrush x:Key="TypeBrush" Color="#4EC9B0"/>
+        <SolidColorBrush x:Key="NumberBrush" Color="#B5CEA8"/>
+        <SolidColorBrush x:Key="StringBrush" Color="#CE9178"/>
+        <SolidColorBrush x:Key="PreprocessorBrush" Color="#C586C0"/>
+        <SolidColorBrush x:Key="BuiltinBrush" Color="#DCDCAA"/>
+        
+        <!-- UI -->
+        <SolidColorBrush x:Key="ToolBarBackgroundBrush" Color="#2D2D30"/>
+        <SolidColorBrush x:Key="StatusBarBackgroundBrush" Color="#2D2D30"/>
+        <SolidColorBrush x:Key="TabBackgroundBrush" Color="#252526"/>
+        <SolidColorBrush x:Key="TabForegroundBrush" Color="#CCCCCC"/>
+        <SolidColorBrush x:Key="TabSelectedBackgroundBrush" Color="#1E1E1E"/>
+        <SolidColorBrush x:Key="BorderBrush" Color="#3E3E42"/>
+        <SolidColorBrush x:Key="ButtonHoverBackgroundBrush" Color="#3E3E42"/>
+        <SolidColorBrush x:Key="ButtonPressedBackgroundBrush" Color="#007ACC"/>
+
+        <!-- ===== GLOBAL STYLES ===== -->
+        <Style TargetType="Window">
+            <Setter Property="Background" Value="{StaticResource PrimaryBackgroundBrush}"/>
+            <Setter Property="Foreground" Value="{StaticResource PrimaryForegroundBrush}"/>
+        </Style>
+
+        <Style TargetType="ToolBar">
+            <Setter Property="Background" Value="{StaticResource ToolBarBackgroundBrush}"/>
+            <Setter Property="Foreground" Value="{StaticResource PrimaryForegroundBrush}"/>
+            <Setter Property="BorderThickness" Value="0,0,0,1"/>
+            <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}"/>
+            <Setter Property="Padding" Value="8"/>
+        </Style>
+
+        <Style TargetType="Button">
+            <Setter Property="Background" Value="{StaticResource TertiaryBackgroundBrush}"/>
+            <Setter Property="Foreground" Value="{StaticResource PrimaryForegroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="8,4"/>
+            <Setter Property="Margin" Value="2"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="{StaticResource ButtonHoverBackgroundBrush}"/>
+                </Trigger>
+                <Trigger Property="IsPressed" Value="True">
+                    <Setter Property="Background" Value="{StaticResource ButtonPressedBackgroundBrush}"/>
+                    <Setter Property="Foreground" Value="White"/>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style TargetType="ComboBox">
+            <Setter Property="Background" Value="{StaticResource SecondaryBackgroundBrush}"/>
+            <Setter Property="Foreground" Value="{StaticResource PrimaryForegroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="6"/>
+            <Setter Property="Margin" Value="2"/>
+        </Style>
+
+        <Style TargetType="TextBox">
+            <Setter Property="Background" Value="{StaticResource EditorBackgroundBrush}"/>
+            <Setter Property="Foreground" Value="{StaticResource EditorForegroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="4"/>
+            <Setter Property="Margin" Value="4"/>
+        </Style>
+
+        <Style TargetType="RichTextBox">
+            <Setter Property="Background" Value="{StaticResource EditorBackgroundBrush}"/>
+            <Setter Property="Foreground" Value="{StaticResource EditorForegroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="4"/>
+            <Setter Property="Margin" Value="4"/>
+            <Setter Property="FontFamily" Value="Consolas"/>
+            <Setter Property="FontSize" Value="14"/>
+        </Style>
+
+        <Style TargetType="TabControl">
+            <Setter Property="Background" Value="{StaticResource TabBackgroundBrush}"/>
+        </Style>
+
+        <Style TargetType="TabItem">
+            <Setter Property="Background" Value="{StaticResource TabBackgroundBrush}"/>
+            <Setter Property="Foreground" Value="{StaticResource TabForegroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}"/>
+            <Setter Property="BorderThickness" Value="0,0,0,1"/>
+            <Setter Property="Padding" Value="12,6"/>
+        </Style>
+
+        <Style TargetType="GroupBox">
+            <Setter Property="Foreground" Value="{StaticResource PrimaryForegroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="8"/>
+            <Setter Property="Margin" Value="8"/>
+        </Style>
+
+        <Style TargetType="StatusBar">
+            <Setter Property="Background" Value="{StaticResource StatusBarBackgroundBrush}"/>
+            <Setter Property="Foreground" Value="{StaticResource PrimaryForegroundBrush}"/>
+            <Setter Property="BorderThickness" Value="0,1,0,0"/>
+            <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}"/>
+            <Setter Property="Padding" Value="8"/>
+        </Style>
+
+        <Style TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource PrimaryForegroundBrush}"/>
+        </Style>
+
+        <Style TargetType="CheckBox">
+            <Setter Property="Foreground" Value="{StaticResource PrimaryForegroundBrush}"/>
+            <Setter Property="Margin" Value="8,0,0,0"/>
+        </Style>
+
+        <Style TargetType="Border">
+            <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}"/>
+        </Style>
     </Application.Resources>
 </Application>

--- a/src/GLSLShaderLab.App.Wpf/MainWindow.xaml
+++ b/src/GLSLShaderLab.App.Wpf/MainWindow.xaml
@@ -10,47 +10,71 @@
         Width="1500"
         Loaded="OnLoaded"
         Closing="OnClosing"
-        PreviewKeyDown="OnPreviewKeyDown">
-    <DockPanel>
-        <ToolBar Name="MainToolBar" DockPanel.Dock="Top">
-            <Button Name="OpenButton" Content="Open..." Click="OpenButton_Click" Margin="2"/>
-            <Button Name="SaveButton" Content="Save" Click="SaveButton_Click" Margin="2"/>
-            <Button Name="SaveAsButton" Content="Save As..." Click="SaveAsButton_Click" Margin="2"/>
-            <Separator/>
-            <Button Name="CompileButton" Content="Compile" Click="CompileButton_Click" Margin="2"/>
-            <CheckBox Name="AutoCompileCheckBox" Content="Auto" Checked="AutoCompileCheckBox_OnChanged" Unchecked="AutoCompileCheckBox_OnChanged" Margin="8,0,0,0"/>
-            <Separator/>
-            <Button Name="PlayPauseButton" Content="Pause" Click="PlayPauseButton_Click" Margin="2"/>
-            <Button Name="ResetTimeButton" Content="Reset Time" Click="ResetTimeButton_Click" Margin="2"/>
-            <Button Name="FullscreenButton" Content="Fullscreen" Click="FullscreenButton_Click" Margin="2"/>
-            <Separator/>
-            <TextBlock Text="Mode:" VerticalAlignment="Center" Margin="4,0"/>
-            <ComboBox Name="RenderModeComboBox" Width="120" SelectionChanged="RenderModeComboBox_SelectionChanged">
-                <ComboBoxItem Content="2D" IsSelected="True"/>
-                <ComboBoxItem Content="3D (Advanced)"/>
-            </ComboBox>
-            <TextBlock Text="Model:" VerticalAlignment="Center" Margin="8,0,4,0"/>
-            <ComboBox Name="ModelComboBox" Width="180" SelectionChanged="ModelComboBox_SelectionChanged"/>
-            <Button Name="ResetCameraButton" Content="Reset Camera" Click="ResetCameraButton_Click" Margin="2"/>
-            <Separator/>
-            <TextBlock Text="Template:" VerticalAlignment="Center" Margin="4,0"/>
-            <ComboBox Name="TemplateComboBox" Width="160" SelectionChanged="TemplateComboBox_SelectionChanged"/>
+        PreviewKeyDown="OnPreviewKeyDown"
+        WindowStartupLocation="CenterScreen"
+        Icon="/GLSLShaderLab.App.Wpf;component/Assets/icon.ico">
+    <DockPanel Background="{StaticResource PrimaryBackgroundBrush}">
+        <ToolBar Name="MainToolBar" DockPanel.Dock="Top" Height="50" Padding="8,4" ToolBar.OverflowMode="Never">
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                <!-- File Operations -->
+                <TextBlock Text="📁" FontSize="16" Margin="0,0,4,0" VerticalAlignment="Center"/>
+                <Button Name="OpenButton" Content="Open..." Click="OpenButton_Click" Padding="10,6" Margin="2"/>
+                <Button Name="SaveButton" Content="Save" Click="SaveButton_Click" Padding="10,6" Margin="2"/>
+                <Button Name="SaveAsButton" Content="Save As..." Click="SaveAsButton_Click" Padding="10,6" Margin="2"/>
+                <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" Margin="8,0"/>
+                
+                <!-- Compilation -->
+                <TextBlock Text="⚙️" FontSize="16" Margin="0,0,4,0" VerticalAlignment="Center"/>
+                <Button Name="CompileButton" Content="Compile" Click="CompileButton_Click" Padding="10,6" Margin="2"/>
+                <CheckBox Name="AutoCompileCheckBox" Content="Auto Compile" Checked="AutoCompileCheckBox_OnChanged" Unchecked="AutoCompileCheckBox_OnChanged" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" Margin="8,0"/>
+                
+                <!-- Playback -->
+                <TextBlock Text="▶️" FontSize="16" Margin="0,0,4,0" VerticalAlignment="Center"/>
+                <Button Name="PlayPauseButton" Content="Pause" Click="PlayPauseButton_Click" Padding="10,6" Margin="2"/>
+                <Button Name="ResetTimeButton" Content="Reset Time" Click="ResetTimeButton_Click" Padding="10,6" Margin="2"/>
+                <Button Name="FullscreenButton" Content="Fullscreen" Click="FullscreenButton_Click" Padding="10,6" Margin="2"/>
+                <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" Margin="8,0"/>
+                
+                <!-- Render Settings -->
+                <TextBlock Text="🎨" FontSize="16" Margin="0,0,4,0" VerticalAlignment="Center"/>
+                <TextBlock Text="Mode:" VerticalAlignment="Center" Margin="4,0,4,0"/>
+                <ComboBox Name="RenderModeComboBox" Width="100" SelectionChanged="RenderModeComboBox_SelectionChanged" Padding="6,4" VerticalAlignment="Center">
+                    <ComboBoxItem Content="2D" IsSelected="True"/>
+                    <ComboBoxItem Content="3D (Advanced)"/>
+                </ComboBox>
+                <TextBlock Text="Model:" VerticalAlignment="Center" Margin="8,0,4,0"/>
+                <ComboBox Name="ModelComboBox" Width="150" SelectionChanged="ModelComboBox_SelectionChanged" Padding="6,4" VerticalAlignment="Center"/>
+                <Button Name="ResetCameraButton" Content="Reset Camera" Click="ResetCameraButton_Click" Padding="10,6" Margin="2"/>
+                <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" Margin="8,0"/>
+                
+                <!-- Templates -->
+                <TextBlock Text="📋" FontSize="16" Margin="0,0,4,0" VerticalAlignment="Center"/>
+                <TextBlock Text="Template:" VerticalAlignment="Center" Margin="4,0,4,0"/>
+                <ComboBox Name="TemplateComboBox" Width="140" SelectionChanged="TemplateComboBox_SelectionChanged" Padding="6,4" VerticalAlignment="Center"/>
+            </StackPanel>
+            
+            <!-- Theme Toggle (Right-aligned) -->
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" Margin="8,0"/>
+                <Button Name="ThemeToggleButton" Content="🌓 Light/Dark" Click="ThemeToggleButton_Click" Padding="10,6" Margin="2"/>
+            </StackPanel>
         </ToolBar>
 
-        <StatusBar Name="MainStatusBar" DockPanel.Dock="Bottom">
+        <StatusBar Name="MainStatusBar" DockPanel.Dock="Bottom" Height="28" Padding="4">
             <StatusBarItem>
-                <TextBlock Name="StatusTextBlock" Text="Ready"/>
+                <TextBlock Name="StatusTextBlock" Text="Ready" Foreground="{StaticResource PrimaryForegroundBrush}"/>
             </StatusBarItem>
             <Separator/>
             <StatusBarItem>
-                <TextBlock Name="FpsTextBlock" Text="FPS: 0"/>
+                <TextBlock Name="FpsTextBlock" Text="FPS: 0" Foreground="{StaticResource SecondaryForegroundBrush}"/>
             </StatusBarItem>
         </StatusBar>
 
-        <Grid Name="MainContentGrid">
+        <Grid Name="MainContentGrid" Background="{StaticResource PrimaryBackgroundBrush}">
             <Grid.RowDefinitions>
                 <RowDefinition Name="PreviewRowDefinition" Height="*"/>
-                <RowDefinition Name="DiagnosticsRowDefinition" Height="220"/>
+                <RowDefinition Name="DiagnosticsRowDefinition" Height="200"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Name="EditorColumnDefinition" Width="1.2*"/>
@@ -58,59 +82,87 @@
             </Grid.ColumnDefinitions>
 
             <Grid Name="EditorPaneGrid" Grid.Row="0" Grid.Column="0" Margin="8">
-                <TabControl Name="ShaderEditorsTabControl">
-                    <TabItem Header="Fragment Shader">
-                        <RichTextBox Name="EditorTextBox"
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                
+                <TextBlock Text="📝 Shader Editor" FontSize="14" FontWeight="Bold" Margin="0,0,0,8" Foreground="{StaticResource AccentBrush}"/>
+                
+                <TabControl Name="ShaderEditorsTabControl" Grid.Row="1" Background="{StaticResource SecondaryBackgroundBrush}" Foreground="{StaticResource PrimaryForegroundBrush}">
+                    <TabItem Header="Fragment Shader" Background="{StaticResource TabBackgroundBrush}" Foreground="{StaticResource TabForegroundBrush}">
+                        <Border BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" Background="{StaticResource EditorBackgroundBrush}">
+                            <RichTextBox Name="EditorTextBox"
                                      Margin="4"
                                      FontFamily="Consolas"
                                      FontSize="14"
                                      VerticalScrollBarVisibility="Auto"
                                      HorizontalScrollBarVisibility="Auto"
                                      PreviewMouseWheel="EditorTextBox_PreviewMouseWheel"
-                                     TextChanged="EditorTextBox_TextChanged"/>
+                                     TextChanged="EditorTextBox_TextChanged"
+                                     Background="{StaticResource EditorBackgroundBrush}"
+                                     Foreground="{StaticResource EditorForegroundBrush}"/>
+                        </Border>
                     </TabItem>
-                    <TabItem Name="VertexEditorTab" Header="Vertex Shader (3D)">
-                        <RichTextBox Name="VertexEditorTextBox"
+                    <TabItem Name="VertexEditorTab" Header="Vertex Shader (3D)" Background="{StaticResource TabBackgroundBrush}" Foreground="{StaticResource TabForegroundBrush}">
+                        <Border BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" Background="{StaticResource EditorBackgroundBrush}">
+                            <RichTextBox Name="VertexEditorTextBox"
                                      Margin="4"
                                      FontFamily="Consolas"
                                      FontSize="14"
                                      VerticalScrollBarVisibility="Auto"
                                      HorizontalScrollBarVisibility="Auto"
                                      PreviewMouseWheel="EditorTextBox_PreviewMouseWheel"
-                                     TextChanged="EditorTextBox_TextChanged"/>
+                                     TextChanged="EditorTextBox_TextChanged"
+                                     Background="{StaticResource EditorBackgroundBrush}"
+                                     Foreground="{StaticResource EditorForegroundBrush}"/>
+                        </Border>
                     </TabItem>
                 </TabControl>
             </Grid>
 
-            <Grid Name="PreviewPaneGrid" Grid.Row="0" Grid.Column="1">
+            <Grid Name="PreviewPaneGrid" Grid.Row="0" Grid.Column="1" Margin="8,8,8,0">
                 <Grid.RowDefinitions>
                     <RowDefinition Name="PreviewHeaderRowDefinition" Height="Auto"/>
                     <RowDefinition Height="*"/>
                     <RowDefinition Name="PreviewChannelsRowDefinition" Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <TextBlock Name="PreviewTitleTextBlock" Text="Preview" FontWeight="Bold" Margin="8"/>
-                <Border Name="PreviewBorder" Grid.Row="1" Margin="8" BorderBrush="#444" BorderThickness="1">
+                <TextBlock Name="PreviewTitleTextBlock" Text="👁️ Preview" FontWeight="Bold" FontSize="14" Margin="0,0,0,8" Foreground="{StaticResource AccentBrush}"/>
+                <Border Name="PreviewBorder" Grid.Row="1" BorderBrush="{StaticResource BorderBrush}" BorderThickness="2" CornerRadius="4" Background="{StaticResource SecondaryBackgroundBrush}">
                     <wf:WindowsFormsHost Name="PreviewHost"/>
                 </Border>
 
-                <UniformGrid Name="ChannelButtonsGrid" Grid.Row="2" Columns="4" Margin="8" HorizontalAlignment="Stretch">
-                    <Button Content="Load iChannel0" Click="LoadChannel0_Click" Margin="2"/>
-                    <Button Content="Load iChannel1" Click="LoadChannel1_Click" Margin="2"/>
-                    <Button Content="Load iChannel2" Click="LoadChannel2_Click" Margin="2"/>
-                    <Button Content="Load iChannel3" Click="LoadChannel3_Click" Margin="2"/>
+                <UniformGrid Name="ChannelButtonsGrid" Grid.Row="2" Columns="4" Margin="0,8,0,0" HorizontalAlignment="Stretch">
+                    <Button Content="Load iChannel0" Click="LoadChannel0_Click" Margin="2" Padding="6,4"/>
+                    <Button Content="Load iChannel1" Click="LoadChannel1_Click" Margin="2" Padding="6,4"/>
+                    <Button Content="Load iChannel2" Click="LoadChannel2_Click" Margin="2" Padding="6,4"/>
+                    <Button Content="Load iChannel3" Click="LoadChannel3_Click" Margin="2" Padding="6,4"/>
                 </UniformGrid>
             </Grid>
 
-            <GroupBox Name="DiagnosticsGroupBox" Header="Diagnostics" Grid.Row="1" Grid.ColumnSpan="2" Margin="8">
-                <TextBox Name="DiagnosticsTextBox"
+            <Grid Grid.Row="1" Grid.ColumnSpan="2" Margin="8" Name="DiagnosticsGroupBox">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                
+                <TextBlock Text="🔍 Diagnostics" FontSize="14" FontWeight="Bold" Margin="0,0,0,8" Foreground="{StaticResource AccentBrush}"/>
+                
+                <Border Grid.Row="1" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="2" Background="{StaticResource EditorBackgroundBrush}">
+                    <TextBox Name="DiagnosticsTextBox"
                          FontFamily="Consolas"
                          FontSize="12"
                          IsReadOnly="True"
                          TextWrapping="Wrap"
+                         AcceptsReturn="True"
                          VerticalScrollBarVisibility="Auto"
-                         HorizontalScrollBarVisibility="Auto"/>
-            </GroupBox>
+                         HorizontalScrollBarVisibility="Auto"
+                         Padding="8"
+                         Background="{StaticResource EditorBackgroundBrush}"
+                         Foreground="{StaticResource EditorForegroundBrush}"/>
+                </Border>
+            </Grid>
         </Grid>
     </DockPanel>
 </Window>

--- a/src/GLSLShaderLab.App.Wpf/MainWindow.xaml.cs
+++ b/src/GLSLShaderLab.App.Wpf/MainWindow.xaml.cs
@@ -25,19 +25,11 @@ public partial class MainWindow : Window
     private const double MinEditorFontSize = 10d;
     private const double MaxEditorFontSize = 30d;
     private const double EditorFontStep = 1d;
+    
+    // Theme Support
+    private enum AppThemeMode { Dark, Light }
+    private AppThemeMode _currentTheme = AppThemeMode.Dark;
     private static readonly WpfBrush EditorDefaultForeground = CreateBrush("#D4D4D4");
-    private static readonly (Regex Pattern, WpfBrush Brush, FontWeight? Weight)[] GlslHighlightRules =
-    [
-        (new Regex(@"//.*$", RegexOptions.Compiled | RegexOptions.Multiline), CreateBrush("#6A9955"), null),
-        (new Regex(@"/\*.*?\*/", RegexOptions.Compiled | RegexOptions.Singleline), CreateBrush("#6A9955"), null),
-        (new Regex("^\\s*#\\w+.*$", RegexOptions.Compiled | RegexOptions.Multiline), CreateBrush("#C586C0"), null),
-        (new Regex("\"(?:\\\\.|[^\"\\\\])*\"", RegexOptions.Compiled), CreateBrush("#CE9178"), null),
-        (new Regex(@"\b\d+(?:\.\d+)?(?:[eE][+\-]?\d+)?[fFuU]?\b", RegexOptions.Compiled), CreateBrush("#B5CEA8"), null),
-        (new Regex(@"\b(?:if|else|for|while|do|switch|case|default|break|continue|discard|return|const|in|out|inout|uniform|layout|precision|struct)\b", RegexOptions.Compiled), CreateBrush("#569CD6"), FontWeights.SemiBold),
-        (new Regex(@"\b(?:void|bool|int|uint|float|double|vec2|vec3|vec4|ivec2|ivec3|ivec4|uvec2|uvec3|uvec4|bvec2|bvec3|bvec4|mat2|mat3|mat4|mat2x2|mat2x3|mat2x4|mat3x2|mat3x3|mat3x4|mat4x2|mat4x3|mat4x4|sampler1D|sampler2D|sampler3D|samplerCube|sampler2DArray|sampler2DShadow)\b", RegexOptions.Compiled), CreateBrush("#4EC9B0"), null),
-        (new Regex(@"\bgl_[A-Za-z0-9_]*\b", RegexOptions.Compiled), CreateBrush("#DCDCAA"), null),
-        (new Regex(@"\b(?:iResolution|iTime|iTimeDelta|iFrame|iMouse|iDate|iChannelTime|iChannelResolution|iChannel0|iChannel1|iChannel2|iChannel3|mainImage|fragColor|fragCoord|VertexPos|vertex)\b", RegexOptions.Compiled), CreateBrush("#DCDCAA"), null),
-    ];
     private readonly SessionStore _sessionStore = new();
     private readonly ShaderToyRenderer _renderer = new();
     private readonly DispatcherTimer _renderTimer;
@@ -64,6 +56,38 @@ public partial class MainWindow : Window
     private bool _isOrbitingCamera;
     private System.Drawing.Point _lastMousePosition;
     private bool _isApplyingSyntaxHighlighting;
+
+    private (Regex Pattern, WpfBrush Brush, FontWeight? Weight)[] GetGlslHighlightRules()
+    {
+        return _currentTheme switch
+        {
+            AppThemeMode.Dark => new []
+            {
+                (new Regex(@"//.*$", RegexOptions.Compiled | RegexOptions.Multiline), CreateBrush("#6A9955"), (FontWeight?)null),
+                (new Regex(@"/\*.*?\*/", RegexOptions.Compiled | RegexOptions.Singleline), CreateBrush("#6A9955"), (FontWeight?)null),
+                (new Regex("^\\s*#\\w+.*$", RegexOptions.Compiled | RegexOptions.Multiline), CreateBrush("#C586C0"), (FontWeight?)null),
+                (new Regex("\"(?:\\\\.|[^\"\\\\])*\"", RegexOptions.Compiled), CreateBrush("#CE9178"), (FontWeight?)null),
+                (new Regex(@"\b\d+(?:\.\d+)?(?:[eE][+\-]?\d+)?[fFuU]?\b", RegexOptions.Compiled), CreateBrush("#B5CEA8"), (FontWeight?)null),
+                (new Regex(@"\b(?:if|else|for|while|do|switch|case|default|break|continue|discard|return|const|in|out|inout|uniform|layout|precision|struct)\b", RegexOptions.Compiled), CreateBrush("#569CD6"), FontWeights.SemiBold),
+                (new Regex(@"\b(?:void|bool|int|uint|float|double|vec2|vec3|vec4|ivec2|ivec3|ivec4|uvec2|uvec3|uvec4|bvec2|bvec3|bvec4|mat2|mat3|mat4|mat2x2|mat2x3|mat2x4|mat3x2|mat3x3|mat3x4|mat4x2|mat4x3|mat4x4|sampler1D|sampler2D|sampler3D|samplerCube|sampler2DArray|sampler2DShadow)\b", RegexOptions.Compiled), CreateBrush("#4EC9B0"), (FontWeight?)null),
+                (new Regex(@"\bgl_[A-Za-z0-9_]*\b", RegexOptions.Compiled), CreateBrush("#DCDCAA"), (FontWeight?)null),
+                (new Regex(@"\b(?:iResolution|iTime|iTimeDelta|iFrame|iMouse|iDate|iChannelTime|iChannelResolution|iChannel0|iChannel1|iChannel2|iChannel3|mainImage|fragColor|fragCoord|VertexPos|vertex)\b", RegexOptions.Compiled), CreateBrush("#DCDCAA"), (FontWeight?)null),
+            },
+            AppThemeMode.Light => new []
+            {
+                (new Regex(@"//.*$", RegexOptions.Compiled | RegexOptions.Multiline), CreateBrush("#008000"), (FontWeight?)null),
+                (new Regex(@"/\*.*?\*/", RegexOptions.Compiled | RegexOptions.Singleline), CreateBrush("#008000"), (FontWeight?)null),
+                (new Regex("^\\s*#\\w+.*$", RegexOptions.Compiled | RegexOptions.Multiline), CreateBrush("#0000FF"), (FontWeight?)null),
+                (new Regex("\"(?:\\\\.|[^\"\\\\])*\"", RegexOptions.Compiled), CreateBrush("#A31515"), (FontWeight?)null),
+                (new Regex(@"\b\d+(?:\.\d+)?(?:[eE][+\-]?\d+)?[fFuU]?\b", RegexOptions.Compiled), CreateBrush("#098658"), (FontWeight?)null),
+                (new Regex(@"\b(?:if|else|for|while|do|switch|case|default|break|continue|discard|return|const|in|out|inout|uniform|layout|precision|struct)\b", RegexOptions.Compiled), CreateBrush("#0000FF"), FontWeights.SemiBold),
+                (new Regex(@"\b(?:void|bool|int|uint|float|double|vec2|vec3|vec4|ivec2|ivec3|ivec4|uvec2|uvec3|uvec4|bvec2|bvec3|bvec4|mat2|mat3|mat4|mat2x2|mat2x3|mat2x4|mat3x2|mat3x3|mat3x4|mat4x2|mat4x3|mat4x4|sampler1D|sampler2D|sampler3D|samplerCube|sampler2DArray|sampler2DShadow)\b", RegexOptions.Compiled), CreateBrush("#2B91AF"), (FontWeight?)null),
+                (new Regex(@"\bgl_[A-Za-z0-9_]*\b", RegexOptions.Compiled), CreateBrush("#795E26"), (FontWeight?)null),
+                (new Regex(@"\b(?:iResolution|iTime|iTimeDelta|iFrame|iMouse|iDate|iChannelTime|iChannelResolution|iChannel0|iChannel1|iChannel2|iChannel3|mainImage|fragColor|fragCoord|VertexPos|vertex)\b", RegexOptions.Compiled), CreateBrush("#795E26"), (FontWeight?)null),
+            },
+            _ => Array.Empty<(Regex, WpfBrush, FontWeight?)>()
+        };
+    }
 
     public MainWindow()
     {
@@ -480,6 +504,71 @@ public partial class MainWindow : Window
         AppendDiagnostic("Camera reset.");
     }
 
+    private void ThemeToggleButton_Click(object sender, RoutedEventArgs e)
+    {
+        _currentTheme = _currentTheme == AppThemeMode.Dark ? AppThemeMode.Light : AppThemeMode.Dark;
+        ApplyTheme();
+        AppendDiagnostic($"Theme changed to: {_currentTheme}");
+        
+        // Re-highlight code with new theme colors
+        if (EditorTextBox.Document.ContentEnd != EditorTextBox.Document.ContentStart)
+        {
+            ApplySyntaxHighlighting(EditorTextBox);
+        }
+        if (VertexEditorTextBox.Document.ContentEnd != VertexEditorTextBox.Document.ContentStart)
+        {
+            ApplySyntaxHighlighting(VertexEditorTextBox);
+        }
+    }
+
+    private void ApplyTheme()
+    {
+        var themeDict = _currentTheme == AppThemeMode.Dark 
+            ? (ResourceDictionary)Resources["DarkTheme"]
+            : (ResourceDictionary)Resources["LightTheme"];
+
+        if (themeDict == null)
+        {
+            return;
+        }
+
+        // Update merged resources with new theme colors
+        var updateColors = new Dictionary<string, SolidColorBrush>
+        {
+            { "PrimaryBackgroundBrush", CreateColorBrush(_currentTheme == AppThemeMode.Dark ? "#1E1E1E" : "#FFFFFF") },
+            { "SecondaryBackgroundBrush", CreateColorBrush(_currentTheme == AppThemeMode.Dark ? "#252526" : "#F5F5F5") },
+            { "TertiaryBackgroundBrush", CreateColorBrush(_currentTheme == AppThemeMode.Dark ? "#2D2D30" : "#EFEFEF") },
+            { "PrimaryForegroundBrush", CreateColorBrush(_currentTheme == AppThemeMode.Dark ? "#E0E0E0" : "#1E1E1E") },
+            { "SecondaryForegroundBrush", CreateColorBrush(_currentTheme == AppThemeMode.Dark ? "#A0A0A0" : "#5A5A5A") },
+            { "EditorBackgroundBrush", CreateColorBrush(_currentTheme == AppThemeMode.Dark ? "#1E1E1E" : "#FFFFFF") },
+            { "EditorForegroundBrush", CreateColorBrush(_currentTheme == AppThemeMode.Dark ? "#D4D4D4" : "#000000") },
+            { "ToolBarBackgroundBrush", CreateColorBrush(_currentTheme == AppThemeMode.Dark ? "#2D2D30" : "#F5F5F5") },
+            { "StatusBarBackgroundBrush", CreateColorBrush(_currentTheme == AppThemeMode.Dark ? "#2D2D30" : "#F5F5F5") },
+            { "TabBackgroundBrush", CreateColorBrush(_currentTheme == AppThemeMode.Dark ? "#252526" : "#EFEFEF") },
+            { "TabForegroundBrush", CreateColorBrush(_currentTheme == AppThemeMode.Dark ? "#CCCCCC" : "#333333") },
+            { "TabSelectedBackgroundBrush", CreateColorBrush(_currentTheme == AppThemeMode.Dark ? "#1E1E1E" : "#FFFFFF") },
+            { "BorderBrush", CreateColorBrush(_currentTheme == AppThemeMode.Dark ? "#3E3E42" : "#CCCCCC") },
+            { "ButtonHoverBackgroundBrush", CreateColorBrush(_currentTheme == AppThemeMode.Dark ? "#3E3E42" : "#E0E0E0") },
+            { "ButtonPressedBackgroundBrush", CreateColorBrush(_currentTheme == AppThemeMode.Dark ? "#007ACC" : "#0066CC") },
+        };
+
+        foreach (var kvp in updateColors)
+        {
+            if (Resources.Contains(kvp.Key))
+            {
+                Resources[kvp.Key] = kvp.Value;
+            }
+        }
+    }
+
+    private static SolidColorBrush CreateColorBrush(string hexColor)
+    {
+        var color = (System.Windows.Media.Color)System.Windows.Media.ColorConverter.ConvertFromString(hexColor)!;
+        var brush = new SolidColorBrush(color);
+        brush.Freeze();
+        return brush;
+    }
+
     private void LoadChannel(int channel)
     {
         if (_glControl is null)
@@ -845,12 +934,17 @@ public partial class MainWindow : Window
         try
         {
             var document = editor.Document;
+            var defaultForeground = _currentTheme == AppThemeMode.Dark 
+                ? CreateBrush("#D4D4D4") 
+                : CreateBrush("#000000");
+                
             var fullRange = new TextRange(document.ContentStart, document.ContentEnd);
-            fullRange.ApplyPropertyValue(TextElement.ForegroundProperty, EditorDefaultForeground);
+            fullRange.ApplyPropertyValue(TextElement.ForegroundProperty, defaultForeground);
             fullRange.ApplyPropertyValue(TextElement.FontWeightProperty, FontWeights.Normal);
 
             var text = GetEditorText(editor);
-            foreach (var rule in GlslHighlightRules)
+            var highlightRules = GetGlslHighlightRules();
+            foreach (var rule in highlightRules)
             {
                 foreach (Match match in rule.Pattern.Matches(text))
                 {
@@ -914,3 +1008,4 @@ public partial class MainWindow : Window
         return brush;
     }
 }
+


### PR DESCRIPTION
- Add comprehensive dark (default) and light themes in App.xaml
- Replace hardcoded colors with theme-aware resource brushes
- Improve syntax highlighting contrast for both themes
- Add theme toggle button (🌓 Light/Dark) to toolbar
- Improve toolbar layout with section icons and grouping
- Add section headers (Editor, Preview, Diagnostics) with accent colors
- Improve border styling and visual hierarchy
- Fix DiagnosticsGroupBox naming for fullscreen compatibility
- Dark theme: VSCode-style colors with high contrast
- Light theme: VS-style colors with black text on white background